### PR TITLE
Update installation of nvidia drivers

### DIFF
--- a/artifacts/nvidia.yml
+++ b/artifacts/nvidia.yml
@@ -1,7 +1,5 @@
 ---
 - hosts: localhost
   connection: local
-  vars:
-    nvidia_driver_branch: "{{ nvidia_driver_branch }}"
   roles:
     - role: 'nvidia.nvidia_driver'

--- a/artifacts/nvidia.yml
+++ b/artifacts/nvidia.yml
@@ -1,5 +1,7 @@
 ---
 - hosts: localhost
   connection: local
+  vars:
+    nvidia_driver_branch: "{{ nvidia_driver_branch }}"
   roles:
     - role: 'nvidia.nvidia_driver'

--- a/templates/nvidia.yml
+++ b/templates/nvidia.yml
@@ -33,7 +33,7 @@ topology_template:
       type: tosca.nodes.SoftwareComponent
       artifacts:
         nvidia_role:
-          file: NVIDIA.nvidia_driver
+          file: nvidia.nvidia_driver
           type: tosca.artifacts.AnsibleGalaxy.role
       requirements:
         - host: simple_node


### PR DESCRIPTION
Hi,

Using https://github.com/grycap/tosca/blob/main/templates/nvidia.yml

I get this on a deployment:

```bash
[...]

 2024-03-19 13:52:20.468044: Galaxy role NVIDIA.nvidia_driver detected setting to install.

[...]

Install NVIDIA.nvidia_driver with ansible-galaxy.
Galaxy depencies file: [{src: NVIDIA.nvidia_driver}]

[...]

Launch task: nvidia_simple_node_conf_simple_node
Call Ansible
ERROR: the role 'nvidia.nvidia_driver' was not found in /var/tmp/.im/67a67798-e5f7-11ee-babd-f6a1a1a9232e/roles:/etc/ansible/roles:/var/tmp/.im/67a67798-e5f7-11ee-babd-f6a1a1a9232e

The error appears to be in '/var/tmp/.im/67a67798-e5f7-11ee-babd-f6a1a1a9232e/nvidia_simple_node_conf_simple_node_task.yml': line 6, column 5, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

roles:
- role: nvidia.nvidia_driver
^ here

ERROR executing playbook (1/1)

```

I think this may be due to the use of upper case characters?
https://github.com/grycap/tosca/blob/1ab4a99b0f230cbd353d8ce5fc9d786cdea8d20e/templates/nvidia.yml#L36

Instead of lower case?
https://galaxy.ansible.com/ui/standalone/roles/nvidia/nvidia_driver/

Please test this PR to check whether it works.

I am also explicitly passing the variable `nvidia_driver_branch` to the Ansible role, is this not needed?

Thanks,
Sebastian